### PR TITLE
fix: Offsets changes after CS:S 18.02.25 update

### DIFF
--- a/addons/sourcemod/gamedata/selectivebhop.games.txt
+++ b/addons/sourcemod/gamedata/selectivebhop.games.txt
@@ -4,7 +4,7 @@
     {
         "#supported"
         {
-            "engine"    "csgo"
+            "engine"	"css"
         }
 
         "Offsets"
@@ -42,35 +42,35 @@
             "CCSGameMovement::OnLand"
             {
                 "library"    "server"
-                "linux"        "\x55\x89\xE5\x57\x56\x53\x83\xEC\x4C\x8B\x75\x08\xF3\x0F\x10\x45\x0C\xF3\x0F\x11\x45\xE4\x8B\x9E\x54\x0E\x00\x00"
+                "linux"      "@_ZN13CGameMovement6OnLandEf"
             }
 
             // CCSGameMovement::OnLand  v  CCSPlayer::OnLand
             "CCSPlayer::OnLand"
             {
                 "library"    "server"
-                "linux"        "\x55\x89\xE5\x81\xEC\x68\x02\x00\x00\x89\x5D\xF4\x8B\x5D\x08\x89\x75\xF8\x89\x7D\xFC\x89\x1C\x24\xE8\x2A\x2A\x2A\x2A\x85\xC0"
+                "linux"      "@_ZN9CCSPlayer6OnLandEf"
             }
 
             // Str: "player_jump"  ^  CCSGameMovement::CheckJumpButton  ^  CCSGameMovement::  v  CCSGameMovement::OnJump
             "CCSGameMovement::OnJump"
             {
                 "library"    "server"
-                "linux"        "\x55\x89\xE5\x57\x56\x53\x83\xEC\x4C\x8B\x75\x08\xF3\x0F\x10\x45\x0C\xF3\x0F\x11\x45\xE4\x8B\x86\x54\x0E\x00\x00"
+                "linux"      "@_ZN13CGameMovement6OnJumpEf"
             }
 
             // CCSGameMovement::  v  CCSGameMovement::PreventBunnyJumping
             "CCSGameMovement::PreventBunnyJumping"
             {
                 "library"    "server"
-                "linux"        "\x55\xF3\x0F\x10\x0D\x2A\x2A\x2A\x2A\x89\xE5\x8B\x45\x08\x8B\x90\x54\x0E\x00\x00"
+                "linux"      "@_ZN15CCSGameMovement19PreventBunnyJumpingEv"
             }
 
             // CCSGameMovement::  v  CCSGameMovement::CheckJumpButton
             "CCSGameMovement::CheckJumpButton"
             {
                 "library"    "server"
-                "linux"        "\x55\x89\xE5\x81\xEC\xC8\x00\x00\x00\x89\x5D\xF4\x8B\x5D\x08\x89\x75\xF8\x89\x7D\xFC\x8B\x83\x54\x0E\x00\x00"
+                "linux"      "@_ZN13CGameMovement15CheckJumpButtonEv"
             }
         }
 

--- a/addons/sourcemod/scripting/include/SelectiveBhop.inc
+++ b/addons/sourcemod/scripting/include/SelectiveBhop.inc
@@ -4,7 +4,7 @@
 #define _SelectiveBhop_Included
 
 #define SelectiveBhop_V_MAJOR   "1"
-#define SelectiveBhop_V_MINOR   "2"
+#define SelectiveBhop_V_MINOR   "3"
 #define SelectiveBhop_V_PATCH   "0"
 
 #define SelectiveBhop_VERSION   SelectiveBhop_V_MAJOR..."."...SelectiveBhop_V_MINOR..."."...SelectiveBhop_V_PATCH


### PR DESCRIPTION
**Untested**

**Some offsets still need to be verified:**
- [ ] 	 `m_pCSPlayer`
- [ ] 	 `CappingOffset`
- [ ] 	 `PatchBytes`

![Screenshot 2025-02-22 094857](https://github.com/user-attachments/assets/75a9d5a4-b3d1-4778-84ac-6009903b279f)
![Screenshot 2025-02-22 095009](https://github.com/user-attachments/assets/7242aa55-dfec-446f-bc99-d5a51e1c79db)
![Screenshot 2025-02-22 095254](https://github.com/user-attachments/assets/b1747f5e-f900-4921-8580-ebcaf26252d1)
![Screenshot 2025-02-22 095428](https://github.com/user-attachments/assets/2b302a06-df5e-4da4-b304-abec9f3c3888)
![Screenshot 2025-02-22 095619](https://github.com/user-attachments/assets/fb5c2641-9d4b-40ee-8303-7efe9403866d)
